### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/c0d3ch/b6c1a4d3-dc7b-4577-b563-c7c8882e95a8/d2119686-91f4-4a22-911b-71bb92276dae/_apis/work/boardbadge/0cdd8c94-c23f-493f-9e74-6b2e591f1cb4)](https://dev.azure.com/c0d3ch/b6c1a4d3-dc7b-4577-b563-c7c8882e95a8/_boards/board/t/d2119686-91f4-4a22-911b-71bb92276dae/Microsoft.RequirementCategory)
 # uiw-classregister-rf
 API for Class Register


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/c0d3ch/b6c1a4d3-dc7b-4577-b563-c7c8882e95a8/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.